### PR TITLE
Add tooltip and links

### DIFF
--- a/src/theme/DocItem/Layout/Web3Feedback.jsx
+++ b/src/theme/DocItem/Layout/Web3Feedback.jsx
@@ -15,6 +15,34 @@ const PORTAL_ABI = [
   "function attest(tuple(bytes32 schemaId, uint64 expirationDate, bytes subject, bytes attestationData) attestationPayload, bytes[] validationPayload) public payable"
 ];
 
+// Constants for external links
+const VERAX_SCHEMA_URL = "https://explorer.ver.ax/linea/schemas/0xb3cb018b837f70fa9cbb59bcfc59049fb529151399345845bae3d380b81c4120";
+const LINEASCAN_TX_URL = "https://lineascan.build/tx/";
+
+// Tooltip component
+const Tooltip = ({ text }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  
+  return (
+    <div className={styles.tooltipContainer}>
+      <div 
+        className={styles.tooltipTrigger}
+        onMouseEnter={() => setIsVisible(true)}
+        onMouseLeave={() => setIsVisible(false)}
+        onClick={() => setIsVisible(!isVisible)}
+      >
+        <span className={styles.infoIcon}>ⓘ</span>
+        <span className={styles.whatIsThis}>What is this?</span>
+      </div>
+      {isVisible && (
+        <div className={styles.tooltipContent}>
+          {text}
+        </div>
+      )}
+    </div>
+  );
+};
+
 const Web3Feedback = () => {
   const { colorMode } = useColorMode();
   const [theme, setTheme] = useState(colorMode);
@@ -23,6 +51,7 @@ const Web3Feedback = () => {
   const [error, setError] = useState(null);
   const [currentUrl, setCurrentUrl] = useState("");
   const [debugInfo, setDebugInfo] = useState(null);
+  const [transactionHash, setTransactionHash] = useState(null);
   
   // Get MetaMask context
   const { 
@@ -57,6 +86,7 @@ const Web3Feedback = () => {
     setIsSubmitting(true);
     setError(null);
     setDebugInfo(null);
+    setTransactionHash(null);
     
     try {
       console.log("Connected wallet address:", metaMaskAccount);
@@ -190,13 +220,10 @@ const Web3Feedback = () => {
       });
       
       console.log("Transaction sent! Hash:", txHash);
+      setTransactionHash(txHash);
       setFeedbackSubmitted(true);
       
-      // Reset after 5 seconds
-      setTimeout(() => {
-        setFeedbackSubmitted(false);
-        setDebugInfo(null);
-      }, 5000);
+      // The thank you message will now persist until the page is refreshed
       
     } catch (error) {
       console.error("Error submitting feedback:", error);
@@ -210,12 +237,36 @@ const Web3Feedback = () => {
     <div className={styles.feedbackContainer}>
       <div className={styles.feedbackPrompt}>
         {feedbackSubmitted ? (
-          <div className={styles.thankYouMessage}>
-            Thank you for your feedback!
+          <div className={styles.feedbackSuccess}>
+            <div className={styles.thankYouMessage}>
+              Thank you for your feedback!
+            </div>
+            <div className={styles.veraxLinks}>
+              <a 
+                href={VERAX_SCHEMA_URL} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                className={styles.veraxLink}
+              >
+                View all feedback on the Verax explorer
+              </a>
+              {transactionHash && (
+                <a 
+                  href={`${LINEASCAN_TX_URL}${transactionHash}`} 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  className={styles.veraxLink}
+                >
+                  View your transaction on LineaScan
+                </a>
+              )}
+            </div>
           </div>
         ) : (
           <>
-            <span>Was this page helpful?</span>
+            <div className={styles.feedbackHeader}>
+              <span>Was this page helpful?</span>
+            </div>
             <div className={styles.feedbackButtons}>
               <button
                 className={`${styles.feedbackButton} ${styles.thumbsUp}`}
@@ -234,6 +285,7 @@ const Web3Feedback = () => {
                 👎
               </button>
             </div>
+            <Tooltip text="This is a trial feedback system that uses Verax to record your feedback as onchain attestations on Linea Mainnet. When you vote, submit a transaction in your wallet." />
           </>
         )}
       </div>

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -94,6 +94,32 @@ nav[aria-label="Breadcrumbs"] {
   animation: fadeIn 0.5s ease;
 }
 
+.feedbackSuccess {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.veraxLinks {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.veraxLink {
+  font-size: 0.85rem;
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.veraxLink:hover {
+  text-decoration: underline;
+  opacity: 0.9;
+}
+
 .loadingIndicator {
   margin-top: 0.75rem;
   font-size: 0.9rem;
@@ -130,4 +156,80 @@ html[data-theme='light'] .feedbackButton {
   background-color: #f8f7f2;
   border-color: var(--ifm-color-emphasis-300);
   color: var(--ifm-font-color-base);
+}
+
+/* Tooltip styles */
+.feedbackHeader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.tooltipContainer {
+  position: relative;
+  display: inline-block;
+  margin-top: 8px;
+}
+
+.tooltipTrigger {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.85rem;
+}
+
+.infoIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.875rem;
+  border-radius: 50%;
+}
+
+.whatIsThis {
+  font-size: 0.75rem;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.tooltipContent {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 8px;
+  padding: 8px 12px;
+  background-color: var(--ifm-color-emphasis-900);
+  color: var(--ifm-color-emphasis-0);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  width: max-content;
+  max-width: 250px;
+  z-index: 10;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.tooltipContent::after {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent var(--ifm-color-emphasis-900) transparent;
+}
+
+/* Dark mode tooltip */
+html[data-theme='dark'] .tooltipContent {
+  background-color: var(--ifm-color-emphasis-800);
+  color: var(--ifm-color-emphasis-0);
+}
+
+html[data-theme='dark'] .tooltipContent::after {
+  border-color: transparent transparent var(--ifm-color-emphasis-800) transparent;
 }

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -210,7 +210,7 @@ html[data-theme='light'] .feedbackButton {
   width: max-content;
   max-width: 250px;
   z-index: 10;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 15%);
 }
 
 .tooltipContent::after {


### PR DESCRIPTION
- Add a tooltip explaining briefly what the component is/does
- Add links that appear after a transaction is submitted:
  - View all attestations on Verax explorer. This would ideally link directly to the attestation they just made, but I don't think this is viable as there's no (easy?) way to immediately get the attestation ID and insert that into the link. 
  - View transaction on Lineascan.
- Also adjusts behaviour so that, after submitting an attestation, the above links persist until a page refresh or departure, rather than just for a few seconds. This gives users the chance to actually access the links and also assumes that people will not want to submit feedback multiple times in quick succession (unlikely as it costs). 